### PR TITLE
fix(docker): resolve Poetry build error by updating deprecated --no-dev flag (close #23)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ COPY pyproject.toml poetry.lock ./
 RUN poetry config virtualenvs.create false
 
 # Install project dependencies
-RUN poetry install --no-root --no-dev
+RUN poetry install --no-root --without dev
 
 # Copy the rest of the application
 COPY . .


### PR DESCRIPTION
## Description  
This PR fixes a Docker build failure caused by Poetry’s deprecated `--no-dev` flag, which prevents users from building the project as reported in #23.  