### PR TITLE
Fix/readme and docker compose for v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ If you want to know more about GH Copilot suspension risk, read this https://git
     git clone https://github.com/jjleng/copilot-more.git
     cd copilot-more
     # run the server. Ensure you either have the refresh token in the .env file or pass it as an environment variable.
+    # If you cannot find the `docker-compose` command, try the `docker compose` command as well.
     docker-compose up --build
     ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   app:
     build:


### PR DESCRIPTION
## Changing

1. Add guidance to run the `docker compose` command if you are already running only the deprecated `docker-compose` command
2. The version attribute is no longer needed in V2 of docker compose, so it was removed

## complementary

Since Compose V2 has been declared General Availability, Compose V1 with docker-compose is now "deprecated" (possibly obsolete), and you can already use docker Compose V2 is already used automatically when using the docker-compose command.
After EOL, the docker-compose alias will be maintained, but you will no longer be able to choose to enable or disable V2 from the Docker Desktop user interface (it will always use V2).

