### PR TITLE
Add platform-specific signal handling for Windows

### DIFF
--- a/copilot_more/server.py
+++ b/copilot_more/server.py
@@ -79,9 +79,19 @@ async def lifespan(app: FastAPI):
                 f"({limit.behavior.value})"
             )
 
+    # Platform-specific signal handling
     loop = asyncio.get_running_loop()
-    for sig in (signal.SIGTERM, signal.SIGINT):
-        loop.add_signal_handler(sig, handle_signal)
+    import sys
+    if sys.platform != 'win32':  # Only add signal handlers on non-Windows platforms
+        for sig in (signal.SIGTERM, signal.SIGINT):
+            loop.add_signal_handler(sig, handle_signal)
+    else:
+        # Alternative approach for Windows
+        import signal
+        # Use the default signal handler on Windows
+        for sig in (signal.SIGTERM, signal.SIGINT):
+            signal.signal(sig, lambda s, f: os._exit(0))
+        logger.info("Using standard signal handlers on Windows")
 
     yield
 


### PR DESCRIPTION
Implement platform-specific signal handling to address a Windows error by using default signal handlers instead of custom ones. This change ensures proper signal management across different operating systems.

Fixes the error:

```
ERROR:    Traceback (most recent call last):
  File "C:\Users\Xeon\AppData\Local\pypoetry\Cache\virtualenvs\copilot-more-6_nlP0Al-py3.13\Lib\site-packages\starlette\routing.py", line 692, in lifespan
    async with self.lifespan_context(app) as maybe_state:
               ~~~~~~~~~~~~~~~~~~~~~^^^^^
  File "C:\Users\Xeon\.pyenv\pyenv-win\versions\3.13.2\Lib\contextlib.py", line 214, in __aenter__
    return await anext(self.gen)
           ^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\Xeon\Downloads\_\_repos\copilot-more\copilot_more\server.py", line 84, in lifespan
    loop.add_signal_handler(sig, handle_signal)
    ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\Xeon\.pyenv\pyenv-win\versions\3.13.2\Lib\asyncio\events.py", line 596, in add_signal_handler
    raise NotImplementedError
NotImplementedError

ERROR:    Application startup failed. Exiting.
```